### PR TITLE
Update cast_mini_media_controls.dart

### DIFF
--- a/lib/player/cast_mini_media_controls.dart
+++ b/lib/player/cast_mini_media_controls.dart
@@ -34,9 +34,11 @@ class _CastMiniMediaControlsState extends State<CastMiniMediaControls> {
   }
 
   _mediaStatusChanged(CastMediaStatus mediaStatus) {
-    setState(() {
-      _mediaStatus = mediaStatus;
-    });
+    if (this.mounted) {
+      setState(() {
+        _mediaStatus = mediaStatus;
+      });
+    }
   }
 
   void _openExtendedMediaControls() {


### PR DESCRIPTION
Unhandled Exception: setState() called after dispose(): _CastMiniMediaControlsState#58a5e(lifecycle state: defunct, not mounted)