### PR TITLE
Update device_picker.dart

### DIFF
--- a/lib/device_picker.dart
+++ b/lib/device_picker.dart
@@ -25,7 +25,7 @@ class _DevicePickerState extends State<DevicePicker> {
 
   void initState() {
     super.initState();
-    widget.serviceDiscovery.changes.listen((List<ChangeRecord> _) {
+    widget?.serviceDiscovery?.changes?.listen((List<ChangeRecord> _) {
       _updateDevices();
     });
     _updateDevices();


### PR DESCRIPTION
Fixed NPE

════════ Exception caught by widgets library ═══════════════════════════════════════════════════════
The following NoSuchMethodError was thrown building Builder:
The getter 'foundServices' was called on null.
Receiver: null
Tried calling: foundServices

The relevant error-causing widget was: 
  MaterialApp file://lib/main.dart:39:20
When the exception was thrown, this was the stack: 
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:51:5)
#1      _DevicePickerState._updateDevices (package:/device_picker.dart:55:33)
#2      _DevicePickerState.initState (package://device_picker.dart:28:5)
#3      StatefulElement._firstBuild (package:flutter/src/widgets/framework.dart:4684:58)
#4      ComponentElement.mount (package:flutter/src/widgets/framework.dart:4520:5)
...
════════════════════════════════════════════════════════════════════════════════════════════════════